### PR TITLE
Refactor transfer status snapshot base

### DIFF
--- a/helpers/date_helper.py
+++ b/helpers/date_helper.py
@@ -1,3 +1,0 @@
-from datetime import date
-def create_date_time(date: date, time: str):
-    return date.strftime(f"%Y-%m-%dT{time}")

--- a/helpers/datetime_helper.py
+++ b/helpers/datetime_helper.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timezone, timedelta
 
 def create_date_time(date: date, time: str):
     return date.strftime(f"%Y-%m-%dT{time}")

--- a/helpers/datetime_helper.py
+++ b/helpers/datetime_helper.py
@@ -1,0 +1,7 @@
+from datetime import date, datetime, timezone
+
+def create_date_time(date: date, time: str):
+    return date.strftime(f"%Y-%m-%dT{time}")
+
+def datetime_utc_now():
+    return datetime.now(timezone.utc)

--- a/reports/functions.splunk
+++ b/reports/functions.splunk
@@ -19,7 +19,7 @@
 {% endmacro %}
 
 {% macro set_time_to_registration_datetime() %}
-| eval _time=strptime(registrationEventDateTime,"%Y-%m-%dT%H:%M:%S")
+| eval _time=strptime(registrationEventDateTime,"%Y-%m-%dT%H:%M:%S%z")
 | sort 0 _time
 {% endmacro %}
 

--- a/reports/gp2gp_integration_sla_status.splunk
+++ b/reports/gp2gp_integration_sla_status.splunk
@@ -1,5 +1,5 @@
 index="$index$"
-| eval _time=strptime(registrationEventDateTime,"%Y-%m-%dT%H:%M:%S")
+| eval _time=strptime(registrationEventDateTime,"%Y-%m-%dT%H:%M:%S%z")
 {% from 'functions.splunk' import
 calculate_transfer_compatibility,
 filter_non_transfers,

--- a/reports/gp2gp_outcome_report.splunk
+++ b/reports/gp2gp_outcome_report.splunk
@@ -1,5 +1,5 @@
 index="$index$"
-| eval _time=strptime(registrationEventDateTime,"%Y-%m-%dT%H:%M:%S")
+| eval _time=strptime(registrationEventDateTime,"%Y-%m-%dT%H:%M:%S%z")
 | sort 0 _time
 
 {% from 'functions.splunk' import 

--- a/reports/gp2gp_sla_outcomes.splunk
+++ b/reports/gp2gp_sla_outcomes.splunk
@@ -1,5 +1,5 @@
 index="$index$"
-| eval _time=strptime(registrationEventDateTime,"%Y-%m-%dT%H:%M:%S")
+| eval _time=strptime(registrationEventDateTime,"%Y-%m-%dT%H:%M:%S%z")
 {% from 'functions.splunk' import
 calculate_transfer_compatibility,
 filter_non_transfers,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -11,7 +11,7 @@ import jq
 from helpers.splunk \
     import get_telemetry_from_splunk, get_or_create_index, create_sample_event, set_variables_on_query, \
     create_integration_payload,  create_error_payload, create_transfer_compatibility_payload
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 from jinja2 import Environment, FileSystemLoader
 from dotenv import load_dotenv
 from abc import ABC

--- a/tests/test_integration_sla_status.py
+++ b/tests/test_integration_sla_status.py
@@ -9,6 +9,7 @@ import jq
 from helpers.splunk \
     import get_telemetry_from_splunk, get_or_create_index, create_sample_event, set_variables_on_query, \
     create_integration_payload,  create_error_payload, create_transfer_compatibility_payload
+from helpers.datetime_helper import datetime_utc_now
 from datetime import datetime, timedelta
 from jinja2 import Environment, FileSystemLoader
 from tests.test_base import TestBase, EventType
@@ -22,14 +23,14 @@ class TestIntegrationSlaStatus(TestBase):
         index_name, index = self.create_index()
 
         # reporting window
-        report_start = datetime.today().date().replace(day=1)
-        report_end = datetime.today().date().replace(day=28)
+        report_start = datetime_utc_now().date().replace(day=1)
+        report_end = datetime_utc_now().date().replace(day=28)
 
         try:       
 
             # test requires a date difference of less than 8 days.
-            ehr_response_datetime = datetime.now().replace(day=1)
-            ehr_integrated_datetime = datetime.now().replace(day=7)        
+            ehr_response_datetime = datetime_utc_now().replace(day=1)
+            ehr_integrated_datetime = datetime_utc_now().replace(day=7)        
 
             # test - #1.a - within SLA - integrated under 8 days
 
@@ -61,7 +62,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
                         event_type=EventType.EHR_RESPONSES.value                    
                     )),
                 sourcetype="myevent")
@@ -70,7 +71,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime.now() + timedelta(days=9)).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(datetime_utc_now() + timedelta(days=9)).strftime("%Y-%m-%dT%H:%M:%S"),
                         event_type=EventType.EHR_INTEGRATIONS.value                    
                     )),
                 sourcetype="myevent")
@@ -103,8 +104,8 @@ class TestIntegrationSlaStatus(TestBase):
         index_name, index = self.create_index()
 
         # reporting window
-        report_start = datetime.today().date().replace(day=1)
-        report_end = datetime.today().date().replace(day=28)
+        report_start = datetime_utc_now().date().replace(day=1)
+        report_end = datetime_utc_now().date().replace(day=28)
 
         try:              
 
@@ -116,7 +117,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
                         event_type=EventType.EHR_RESPONSES.value                    
                     )),
                 sourcetype="myevent")
@@ -126,7 +127,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime.now() + timedelta(days=9)).strftime("%Y-%m-%dT%H:%M:%S"), 
+                        registration_event_datetime=(datetime_utc_now() + timedelta(days=9)).strftime("%Y-%m-%dT%H:%M:%S"), 
                         event_type=EventType.EHR_INTEGRATIONS.value                    
                     )),
                 sourcetype="myevent")
@@ -139,7 +140,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
                         event_type=EventType.EHR_RESPONSES.value                    
                     )),
                 sourcetype="myevent")
@@ -148,7 +149,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime.now() + timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(datetime_utc_now() + timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:%S"),
                         event_type=EventType.EHR_INTEGRATIONS.value                    
                     )),
                 sourcetype="myevent")
@@ -184,8 +185,8 @@ class TestIntegrationSlaStatus(TestBase):
         index_name, index = self.create_index()
 
         # reporting window
-        report_start = datetime.today().date().replace(day=1)
-        report_end = datetime.today().date().replace(day=28)
+        report_start = datetime_utc_now().date().replace(day=1)
+        report_end = datetime_utc_now().date().replace(day=28)
 
         try:              
 
@@ -198,7 +199,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime.now() - timedelta(days=9)).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(datetime_utc_now() - timedelta(days=9)).strftime("%Y-%m-%dT%H:%M:%S"),
                         event_type=EventType.EHR_RESPONSES.value                    
                     )),
                 sourcetype="myevent")
@@ -207,7 +208,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime.now()).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(datetime_utc_now()).strftime("%Y-%m-%dT%H:%M:%S"),
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value                    
                     )),
                 sourcetype="myevent")  
@@ -221,7 +222,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime.now() - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(datetime_utc_now() - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%S"),
                         event_type=EventType.EHR_RESPONSES.value                    
                     )),
                 sourcetype="myevent")
@@ -230,7 +231,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime.now().strftime("%Y-%m-%dT%H:%M:%S"), 
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"), 
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value                    
                     )),
                 sourcetype="myevent")      
@@ -266,8 +267,8 @@ class TestIntegrationSlaStatus(TestBase):
         index_name, index = self.create_index()
 
         # reporting window
-        report_start = datetime.today().date().replace(day=1)
-        report_end = datetime.today().date().replace(day=28)
+        report_start = datetime_utc_now().date().replace(day=1)
+        report_end = datetime_utc_now().date().replace(day=28)
 
         try:              
 
@@ -280,7 +281,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime.now() - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(datetime_utc_now() - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%S"),
                         event_type=EventType.EHR_RESPONSES.value                    
                     )),
                 sourcetype="myevent")
@@ -289,7 +290,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime.now().strftime("%Y-%m-%dT%H:%M:%S"), 
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"), 
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value                    
                     )),
                 sourcetype="myevent") 
@@ -306,7 +307,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime.now() - timedelta(days=9)).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(datetime_utc_now() - timedelta(days=9)).strftime("%Y-%m-%dT%H:%M:%S"),
                         event_type=EventType.EHR_RESPONSES.value                    
                     )),
                 sourcetype="myevent")
@@ -315,7 +316,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime.now()).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(datetime_utc_now()).strftime("%Y-%m-%dT%H:%M:%S"),
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value                    
                     )),
                 sourcetype="myevent") 

--- a/tests/test_integration_sla_status.py
+++ b/tests/test_integration_sla_status.py
@@ -40,7 +40,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=ehr_response_datetime.strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=ehr_response_datetime.strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_RESPONSES.value                    
                     )),
                 sourcetype="myevent")
@@ -49,7 +49,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=ehr_integrated_datetime.strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=ehr_integrated_datetime.strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_INTEGRATIONS.value                    
                     )),
                 sourcetype="myevent")
@@ -62,7 +62,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_RESPONSES.value                    
                     )),
                 sourcetype="myevent")
@@ -71,7 +71,9 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime_utc_now() + timedelta(days=9)).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(
+                                datetime_utc_now() + timedelta(days=9)
+                        ).strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_INTEGRATIONS.value                    
                     )),
                 sourcetype="myevent")
@@ -117,17 +119,19 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_RESPONSES.value                    
                     )),
                 sourcetype="myevent")
             
-            #registration_event_datetime must be over 8 days from EHR_RESPONSE event datetime.        
+            # registration_event_datetime must be over 8 days from EHR_RESPONSE event datetime.
             index.submit(
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime_utc_now() + timedelta(days=9)).strftime("%Y-%m-%dT%H:%M:%S"), 
+                        registration_event_datetime=(
+                                datetime_utc_now() + timedelta(days=9)
+                        ).strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_INTEGRATIONS.value                    
                     )),
                 sourcetype="myevent")
@@ -140,7 +144,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_RESPONSES.value                    
                     )),
                 sourcetype="myevent")
@@ -149,7 +153,9 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime_utc_now() + timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(
+                                datetime_utc_now() + timedelta(days=7)
+                        ).strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_INTEGRATIONS.value                    
                     )),
                 sourcetype="myevent")
@@ -199,7 +205,9 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime_utc_now() - timedelta(days=9)).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(
+                                datetime_utc_now() - timedelta(days=9)
+                        ).strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_RESPONSES.value                    
                     )),
                 sourcetype="myevent")
@@ -208,7 +216,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime_utc_now()).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(datetime_utc_now()).strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value                    
                     )),
                 sourcetype="myevent")  
@@ -222,7 +230,9 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime_utc_now() - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(
+                                datetime_utc_now() - timedelta(days=2)
+                        ).strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_RESPONSES.value                    
                     )),
                 sourcetype="myevent")
@@ -231,7 +241,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"), 
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value                    
                     )),
                 sourcetype="myevent")      
@@ -281,7 +291,9 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime_utc_now() - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(
+                                datetime_utc_now() - timedelta(days=2)
+                        ).strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_RESPONSES.value                    
                     )),
                 sourcetype="myevent")
@@ -290,7 +302,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"), 
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value                    
                     )),
                 sourcetype="myevent") 
@@ -307,7 +319,9 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime_utc_now() - timedelta(days=9)).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(
+                                datetime_utc_now() - timedelta(days=9)
+                        ).strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_RESPONSES.value                    
                     )),
                 sourcetype="myevent")
@@ -316,7 +330,7 @@ class TestIntegrationSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=(datetime_utc_now()).strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=(datetime_utc_now()).strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value                    
                     )),
                 sourcetype="myevent") 

--- a/tests/test_integration_sla_status.py
+++ b/tests/test_integration_sla_status.py
@@ -10,7 +10,7 @@ from helpers.splunk \
     import get_telemetry_from_splunk, get_or_create_index, create_sample_event, set_variables_on_query, \
     create_integration_payload,  create_error_payload, create_transfer_compatibility_payload
 from helpers.datetime_helper import datetime_utc_now
-from datetime import datetime, timedelta
+from datetime import timedelta
 from jinja2 import Environment, FileSystemLoader
 from tests.test_base import TestBase, EventType
 

--- a/tests/test_internal_transfers.py
+++ b/tests/test_internal_transfers.py
@@ -28,7 +28,7 @@ class TestInternalTransfers(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_internal_transfer_test#1',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=True,
@@ -42,7 +42,7 @@ class TestInternalTransfers(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_internal_transfer_test#2',
-                        registration_event_datetime="2023-03-10T09:30:00",
+                        registration_event_datetime="2023-03-10T09:30:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,

--- a/tests/test_outcome_table.py
+++ b/tests/test_outcome_table.py
@@ -35,7 +35,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id,
-                        registration_event_datetime="2023-03-10T08:00:00",
+                        registration_event_datetime="2023-03-10T08:00:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(outcome="INTEGRATED")
 
@@ -77,7 +77,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id,
-                        registration_event_datetime="2023-03-10T08:00:00",
+                        registration_event_datetime="2023-03-10T08:00:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(outcome="REJECTED")
 
@@ -119,7 +119,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id,
-                        registration_event_datetime="2023-03-10T08:00:00",
+                        registration_event_datetime="2023-03-10T08:00:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(
                             outcome="FAILED_TO_INTEGRATE")
@@ -162,7 +162,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id,
-                        registration_event_datetime="2023-03-10T08:00:00",
+                        registration_event_datetime="2023-03-10T08:00:00+0000",
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value)
                 ),
                 sourcetype="myevent")
@@ -288,7 +288,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-05-10T04:00:00",
+                        registration_event_datetime="2023-05-10T04:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -301,7 +301,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-05-10T05:00:00",
+                        registration_event_datetime="2023-05-10T05:00:00+0000",
                         event_type=EventType.EHR_REQUESTS.value
                     )),
                 sourcetype="myevent")
@@ -311,7 +311,7 @@ class TestOutcomeTable(TestBase):
                     create_sample_event(
                         conversation_id=conversation_id,
                         registration_event_datetime=now_minus_23_hours.strftime(
-                            "%Y-%m-%dT%H:%M:%S"),
+                            "%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_RESPONSES.value
                     )),
                 sourcetype="myevent")
@@ -324,7 +324,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-05-01T04:00:00",
+                        registration_event_datetime="2023-05-01T04:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -337,7 +337,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-05-01T05:00:00",
+                        registration_event_datetime="2023-05-01T05:00:00+0000",
                         event_type=EventType.EHR_REQUESTS.value
                     )),
                 sourcetype="myevent")
@@ -346,7 +346,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-05-05T07:00:00",
+                        registration_event_datetime="2023-05-05T07:00:00+0000",
                         event_type=EventType.EHR_RESPONSES.value
                     )),
                 sourcetype="myevent")
@@ -398,7 +398,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-05-02T10:00:00",
+                        registration_event_datetime="2023-05-02T10:00:00+0000",
                         event_type=EventType.EHR_REQUESTS.value
                     )),
                 sourcetype="myevent")
@@ -422,7 +422,7 @@ class TestOutcomeTable(TestBase):
                     create_sample_event(
                         conversation_id=conversation_id,
                         registration_event_datetime=now_minus_18_mins.strftime(
-                            "%Y-%m-%dT%H:%M:%S"),
+                            "%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_REQUESTS.value
                     )),
                 sourcetype="myevent")
@@ -479,7 +479,7 @@ class TestOutcomeTable(TestBase):
                     create_sample_event(
                         conversation_id=conversation_id,
                         registration_event_datetime=now_minus_18_mins.strftime(
-                            "%Y-%m-%dT%H:%M:%S"),
+                            "%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_REQUESTS.value
                     )),
                 sourcetype="myevent")
@@ -492,7 +492,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-05-01T05:00:00",
+                        registration_event_datetime="2023-05-01T05:00:00+0000",
                         event_type=EventType.EHR_REQUESTS.value
                     )),
                 sourcetype="myevent")
@@ -544,7 +544,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-05-01T04:00:00",
+                        registration_event_datetime="2023-05-01T04:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -566,7 +566,7 @@ class TestOutcomeTable(TestBase):
                     create_sample_event(
                         conversation_id=conversation_id,
                         registration_event_datetime=now_minus_18_mins.strftime(
-                            "%Y-%m-%dT%H:%M:%S"),
+                            "%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -626,7 +626,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime= now_minus_18_mins.strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime= now_minus_18_mins.strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -645,7 +645,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime = create_date_time(datetime_utc_now(),"04:30:00"),
+                        registration_event_datetime=create_date_time(datetime_utc_now(), "04:30:00+0000"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -700,7 +700,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime = create_date_time(datetime_utc_now(),"07:00:00"),
+                        registration_event_datetime=create_date_time(datetime_utc_now(), "07:00:00+0000"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -719,7 +719,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime = create_date_time(datetime_utc_now(),"04:30:00"),
+                        registration_event_datetime=create_date_time(datetime_utc_now(), "04:30:00+0000"),
                         event_type=EventType.REGISTRATIONS.value,
                         payload=create_registration_payload(dtsMatched=False)
                     )),

--- a/tests/test_outcome_table.py
+++ b/tests/test_outcome_table.py
@@ -10,8 +10,9 @@ from helpers.splunk \
     import get_telemetry_from_splunk, get_or_create_index, create_sample_event, set_variables_on_query, \
     create_integration_payload,  create_error_payload, create_transfer_compatibility_payload, create_registration_payload
 from datetime import datetime, timedelta, date
+from helpers.datetime_helper import datetime_utc_now
 from jinja2 import Environment, FileSystemLoader
-from helpers.date_helper import create_date_time
+from helpers.datetime_helper import create_date_time
 from tests.test_base import TestBase, EventType
 
 
@@ -198,14 +199,14 @@ class TestOutcomeTable(TestBase):
         try:
 
             # reporting window
-            report_start = datetime.today().date().replace(day=1)
-            report_end = datetime.today().date().replace(day=28)            
+            report_start = datetime_utc_now().date().replace(day=1)
+            report_end = datetime_utc_now().date().replace(day=28)            
 
             # test requires a datetime less than 24hrs
-            now_minus_23_hours = datetime.today() - timedelta(hours=23, minutes=0)
+            now_minus_23_hours = datetime_utc_now() - timedelta(hours=23, minutes=0)
             self.LOG.info(f"now_minus_23_hours: {now_minus_23_hours}")
 
-            now_minus_25_hours = datetime.today() - timedelta(hours=25, minutes=0)
+            now_minus_25_hours = datetime_utc_now() - timedelta(hours=25, minutes=0)
             self.LOG.info(f"now_minus_25_hours: {now_minus_25_hours}")
 
             # Outside SLA
@@ -269,8 +270,8 @@ class TestOutcomeTable(TestBase):
         index_name, index = self.create_index()
 
         # reporting window
-        report_start = datetime.today().date().replace(day=1)
-        report_end = datetime.today().date().replace(day=28)
+        report_start = datetime_utc_now().date().replace(day=1)
+        report_end = datetime_utc_now().date().replace(day=28)
 
         try:
 
@@ -279,7 +280,7 @@ class TestOutcomeTable(TestBase):
             conversation_id = 'test_outcome_in_progress_inside_sla'
 
             # test requires a datetime less than 24hrs
-            now_minus_23_hours = datetime.today() - timedelta(hours=23, minutes=0)
+            now_minus_23_hours = datetime_utc_now() - timedelta(hours=23, minutes=0)
             self.LOG.info(f"now_minus_23_hours: {now_minus_23_hours}")
 
             index.submit(
@@ -383,8 +384,8 @@ class TestOutcomeTable(TestBase):
         index_name, index = self.create_index()
 
         # reporting window
-        report_start = datetime.today().date().replace(day=1)
-        report_end = datetime.today().date().replace(day=28)
+        report_start = datetime_utc_now().date().replace(day=1)
+        report_end = datetime_utc_now().date().replace(day=28)
 
         try:
 
@@ -412,7 +413,7 @@ class TestOutcomeTable(TestBase):
             conversation_id = 'test_outcome_technical_failure_3_inside_sla'
 
             # test requires a datetime less than 24hrs
-            now_minus_18_mins = datetime.today() - timedelta(hours=0, minutes=18)
+            now_minus_18_mins = datetime_utc_now() - timedelta(hours=0, minutes=18)
             self.LOG.info(f"now_minus_18_mins: {now_minus_18_mins}")
 
             index.submit(
@@ -459,8 +460,8 @@ class TestOutcomeTable(TestBase):
         index_name, index = self.create_index()
 
         # reporting window
-        report_start = datetime.today().date().replace(day=1)
-        report_end = datetime.today().date().replace(day=28)
+        report_start = datetime_utc_now().date().replace(day=1)
+        report_end = datetime_utc_now().date().replace(day=28)
 
         try:
 
@@ -469,7 +470,7 @@ class TestOutcomeTable(TestBase):
             conversation_id = 'test_outcome_in_progress_2_inside_sla'
 
             # test requires a datetime less than 20mins
-            now_minus_18_mins = datetime.today() - timedelta(hours=0, minutes=18)
+            now_minus_18_mins = datetime_utc_now() - timedelta(hours=0, minutes=18)
             self.LOG.info(f"now_minus_18_mins: {now_minus_18_mins}")
 
             index.submit(
@@ -529,8 +530,8 @@ class TestOutcomeTable(TestBase):
         index_name, index = self.create_index()
 
         # reporting window
-        report_start = datetime.today().date().replace(day=1)
-        report_end = datetime.today().date().replace(day=28)
+        report_start = datetime_utc_now().date().replace(day=1)
+        report_end = datetime_utc_now().date().replace(day=28)
 
         try:
 
@@ -554,7 +555,7 @@ class TestOutcomeTable(TestBase):
             # test 1.b - inside SLA
 
             # test requires a datetime less than 20mins
-            now_minus_18_mins = datetime.today() - timedelta(hours=0, minutes=18)
+            now_minus_18_mins = datetime_utc_now() - timedelta(hours=0, minutes=18)
             self.LOG.info(f"now_minus_18_mins: {now_minus_18_mins}")
 
             conversation_id = 'test_technical_failure_4_inside_sla'
@@ -607,15 +608,15 @@ class TestOutcomeTable(TestBase):
         index_name, index = self.create_index()
 
         # reporting window
-        report_start = datetime.today().date().replace(day=1)
-        report_end = datetime.today().date().replace(day=28)
+        report_start = datetime_utc_now().date().replace(day=1)
+        report_end = datetime_utc_now().date().replace(day=28)
 
         try:
 
             # test 1.a - inside SLA
 
             # test requires a datetime less than 20mins
-            now_minus_18_mins = datetime.today() - timedelta(hours=0, minutes=18)
+            now_minus_18_mins = datetime_utc_now() - timedelta(hours=0, minutes=18)
             self.LOG.info(f"now_minus_18_mins: {now_minus_18_mins}")     
 
             conversation_id = 'test_outcome_in_progress_3_inside_sla'
@@ -643,7 +644,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime = create_date_time(datetime.today(),"04:30:00"),
+                        registration_event_datetime = create_date_time(datetime_utc_now(),"04:30:00"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -685,8 +686,8 @@ class TestOutcomeTable(TestBase):
         index_name, index = self.create_index()
 
         # reporting window
-        report_start = datetime.today().date().replace(day=1)
-        report_end = datetime.today().date().replace(day=28)
+        report_start = datetime_utc_now().date().replace(day=1)
+        report_end = datetime_utc_now().date().replace(day=28)
 
         try:
 
@@ -698,7 +699,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime = create_date_time(datetime.today(),"07:00:00"),
+                        registration_event_datetime = create_date_time(datetime_utc_now(),"07:00:00"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -717,7 +718,7 @@ class TestOutcomeTable(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime = create_date_time(datetime.today(),"04:30:00"),
+                        registration_event_datetime = create_date_time(datetime_utc_now(),"04:30:00"),
                         event_type=EventType.REGISTRATIONS.value,
                         payload=create_registration_payload(dtsMatched=False)
                     )),

--- a/tests/test_outcome_table.py
+++ b/tests/test_outcome_table.py
@@ -203,6 +203,7 @@ class TestOutcomeTable(TestBase):
             report_end = datetime_utc_now().date().replace(day=28)            
 
             # test requires a datetime less than 24hrs
+
             now_minus_23_hours = datetime_utc_now() - timedelta(hours=23, minutes=0)
             self.LOG.info(f"now_minus_23_hours: {now_minus_23_hours}")
 
@@ -215,7 +216,7 @@ class TestOutcomeTable(TestBase):
                     create_sample_event(
                         conversation_id='outside_sla_24_hours',
                         registration_event_datetime=now_minus_25_hours.strftime(
-                            "%Y-%m-%dT%H:%M:%S"),  # needs to be outside 24 hours
+                            "%Y-%m-%dT%H:%M:%S%z"),  # needs to be outside 24 hours
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -229,7 +230,7 @@ class TestOutcomeTable(TestBase):
                     create_sample_event(
                         conversation_id='inside_sla_24_hours',
                         registration_event_datetime=now_minus_23_hours.strftime(
-                            "%Y-%m-%dT%H:%M:%S"),  # needs to be within 24 hours
+                            "%Y-%m-%dT%H:%M:%S%z"),  # needs to be within 24 hours
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"

--- a/tests/test_sla_status.py
+++ b/tests/test_sla_status.py
@@ -9,6 +9,7 @@ from helpers.splunk \
     import get_telemetry_from_splunk, create_sample_event, set_variables_on_query, \
     create_integration_payload,  create_transfer_compatibility_payload
 from datetime import datetime, timedelta
+from helpers.datetime_helper import datetime_utc_now
 from jinja2 import Environment, FileSystemLoader
 from tests.test_base import TestBase,EventType
 
@@ -22,17 +23,17 @@ class TestSlaStatus(TestBase):
         index_name, index = self.create_index()       
 
         # reporting window
-        report_start = datetime.today().date().replace(day=1)
-        report_end = datetime.today().date().replace(day=28)
+        report_start = datetime_utc_now().date().replace(day=1)
+        report_end = datetime_utc_now().date().replace(day=28)
 
         try:
 
             # reporting window
-            yesterday = datetime.today() - timedelta(hours=24)
-            tomorrow = datetime.today() + timedelta(hours=24)
+            yesterday = datetime_utc_now() - timedelta(hours=24)
+            tomorrow = datetime_utc_now() + timedelta(hours=24)
 
             # test requires a datetime less than 24hrs
-            now_minus_23_hours = datetime.today() - timedelta(hours=23, minutes=0)
+            now_minus_23_hours = datetime_utc_now() - timedelta(hours=23, minutes=0)
             self.LOG.info(f"now_minus_20_mins: {now_minus_23_hours}")
 
             # test - #1
@@ -204,7 +205,7 @@ class TestSlaStatus(TestBase):
         try:
 
             # test requires a datetime less than 20mins
-            now_minus_20_mins = datetime.today() - timedelta(hours=0, minutes=15)
+            now_minus_20_mins = datetime_utc_now() - timedelta(hours=0, minutes=15)
             self.LOG.info(f"now_minus_20_mins: {now_minus_20_mins}")
 
             # test - #1 - outside sla
@@ -491,7 +492,7 @@ class TestSlaStatus(TestBase):
             # test #1.b - Eligibile for transfer inside SLA
 
             # test requires a datetime less than 20mins
-            now_minus_20_mins = datetime.today() - timedelta(hours=0, minutes=15)
+            now_minus_20_mins = datetime_utc_now() - timedelta(hours=0, minutes=15)
             self.LOG.info(f"now_minus_20_mins: {now_minus_20_mins}")
 
             index.submit(
@@ -552,14 +553,14 @@ class TestSlaStatus(TestBase):
             conversation_id = 'test_ehr_requesting_inside_sla_test#2.b'
 
             # test requires a datetime less than 20mins
-            now_minus_20_mins = datetime.today() - timedelta(hours=0, minutes=15)
+            now_minus_20_mins = datetime_utc_now() - timedelta(hours=0, minutes=15)
             self.LOG.info(f"now_minus_20_mins: {now_minus_20_mins}")
 
             index.submit(
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime.today().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -635,14 +636,14 @@ class TestSlaStatus(TestBase):
             conversation_id = 'test_ehr_requesting_outside_sla_test#3.b'
 
             # test requires a datetime less than 20mins
-            now_minus_20_mins = datetime.today() - timedelta(hours=0, minutes=15)
+            now_minus_20_mins = datetime_utc_now() - timedelta(hours=0, minutes=15)
             self.LOG.info(f"now_minus_20_mins: {now_minus_20_mins}")
 
             index.submit(
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime.today().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -718,14 +719,14 @@ class TestSlaStatus(TestBase):
             conversation_id = 'test_ehr_requesting_outside_sla_test#4.b'
 
             # test requires a datetime less than 20mins
-            now_minus_20_mins = datetime.today() - timedelta(hours=0, minutes=15)
+            now_minus_20_mins = datetime_utc_now() - timedelta(hours=0, minutes=15)
             self.LOG.info(f"now_minus_20_mins: {now_minus_20_mins}")
 
             index.submit(
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime.today().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -790,14 +791,14 @@ class TestSlaStatus(TestBase):
             conversation_id = 'test_ehr_requesting_outside_sla_test#5.b'
 
             # test requires a datetime less than 20mins
-            now_minus_20_mins = datetime.today() - timedelta(hours=0, minutes=15)
+            now_minus_20_mins = datetime_utc_now() - timedelta(hours=0, minutes=15)
             self.LOG.info(f"now_minus_20_mins: {now_minus_20_mins}")
 
             index.submit(
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime.today().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,

--- a/tests/test_sla_status.py
+++ b/tests/test_sla_status.py
@@ -42,7 +42,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='outside_sla_24_hours_1',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -54,7 +54,7 @@ class TestSlaStatus(TestBase):
                     create_sample_event(
                         conversation_id='inside_sla_24_hours_1',
                         registration_event_datetime=now_minus_23_hours.strftime(
-                            "%Y-%m-%dT%H:%M:%S"),  # needs to be within 24 hours
+                            "%Y-%m-%dT%H:%M:%S%z"),  # needs to be within 24 hours
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -67,7 +67,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_2_outside_sla',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -78,7 +78,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_2_outside_sla',
-                        registration_event_datetime="2023-03-15T09:00:00",
+                        registration_event_datetime="2023-03-15T09:00:00+0000",
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -89,7 +89,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_2_inside_sla',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -100,7 +100,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_2_inside_sla',
-                        registration_event_datetime="2023-03-10T11:00:00",
+                        registration_event_datetime="2023-03-10T11:00:00+0000",
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -113,7 +113,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_3_outside_sla',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -124,7 +124,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_3_outside_sla',
-                        registration_event_datetime="2023-03-15T09:00:00",
+                        registration_event_datetime="2023-03-15T09:00:00+0000",
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -135,7 +135,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_3_outside_sla',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(outcome="REJECTED")
                     )),
@@ -145,7 +145,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_3_inside_sla',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -156,7 +156,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_3_inside_sla',
-                        registration_event_datetime="2023-03-10T11:00:00",
+                        registration_event_datetime="2023-03-10T11:00:00+0000",
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -167,7 +167,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_3_inside_sla',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(outcome="INTEGRATED")
                     )),
@@ -214,7 +214,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_outside_sla_1',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -228,7 +228,7 @@ class TestSlaStatus(TestBase):
                     create_sample_event(
                         conversation_id='test_ehr_sending_outside_sla_2',
                         registration_event_datetime=now_minus_20_mins.strftime(
-                            "%Y-%m-%dT%H:%M:%S"),
+                            "%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -241,7 +241,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_outside_sla_ready_to_integrate',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -252,7 +252,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_outside_sla_ready_to_integrate',
-                        registration_event_datetime="2023-03-10T10:00:00",
+                        registration_event_datetime="2023-03-10T10:00:00+0000",
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -263,7 +263,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_outside_sla_ready_to_integrate',
-                        registration_event_datetime="2023-03-10T11:00:00",
+                        registration_event_datetime="2023-03-10T11:00:00+0000",
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -276,7 +276,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_inside_sla_ready_to_integrate',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -287,7 +287,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_inside_sla_ready_to_integrate',
-                        registration_event_datetime="2023-03-10T09:05:00",
+                        registration_event_datetime="2023-03-10T09:05:00+0000",
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -298,7 +298,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_inside_sla_ready_to_integrate',
-                        registration_event_datetime="2023-03-10T10:00:00",
+                        registration_event_datetime="2023-03-10T10:00:00+0000",
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -311,7 +311,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_inside_sla_integrated',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -322,7 +322,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_inside_sla_integrated',
-                        registration_event_datetime="2023-03-10T09:05:00",
+                        registration_event_datetime="2023-03-10T09:05:00+0000",
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -333,7 +333,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_inside_sla_integrated',
-                        registration_event_datetime="2023-03-10T10:01:00",
+                        registration_event_datetime="2023-03-10T10:01:00+0000",
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -344,7 +344,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_inside_sla_integrated',
-                        registration_event_datetime="2023-03-10T10:30:00",
+                        registration_event_datetime="2023-03-10T10:30:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(outcome="INTEGRATED")
                     )),
@@ -356,7 +356,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_outside_sla_integrated',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -367,7 +367,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_outside_sla_integrated',
-                        registration_event_datetime="2023-03-10T10:00:00",
+                        registration_event_datetime="2023-03-10T10:00:00+0000",
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -378,7 +378,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_outside_sla_integrated',
-                        registration_event_datetime="2023-03-10T10:01:00",
+                        registration_event_datetime="2023-03-10T10:01:00+0000",
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -389,7 +389,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_outside_sla_integrated',
-                        registration_event_datetime="2023-03-10T10:30:00",
+                        registration_event_datetime="2023-03-10T10:30:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(outcome="INTEGRATED")
                     )),
@@ -401,7 +401,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_outside_sla_ehr_sent',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -412,7 +412,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_outside_sla_ehr_sent',
-                        registration_event_datetime="2023-03-10T10:00:00",
+                        registration_event_datetime="2023-03-10T10:00:00+0000",
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -425,7 +425,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_inside_sla_ehr_sent',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -436,7 +436,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id='test_ehr_sending_inside_sla_ehr_sent',
-                        registration_event_datetime="2023-03-10T09:15:00",
+                        registration_event_datetime="2023-03-10T09:15:00+0000",
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -480,7 +480,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         "test_ehr_requesting_outside_sla_test#1.a",
-                        registration_event_datetime="2023-03-10T09:15:00",
+                        registration_event_datetime="2023-03-10T09:15:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -500,7 +500,7 @@ class TestSlaStatus(TestBase):
                     create_sample_event(
                         "test_ehr_requesting_outside_sla_test#1.b",
                         registration_event_datetime=now_minus_20_mins.strftime(
-                            "%Y-%m-%dT%H:%M:%S"),
+                            "%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -517,7 +517,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -530,7 +530,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-03-10T09:30:00",
+                        registration_event_datetime="2023-03-10T09:30:00+0000",
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -541,7 +541,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-03-10T10:00:00",
+                        registration_event_datetime="2023-03-10T10:00:00+0000",
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -560,7 +560,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -574,7 +574,7 @@ class TestSlaStatus(TestBase):
                     create_sample_event(
                         conversation_id=conversation_id,
                         registration_event_datetime=now_minus_20_mins.strftime(
-                            "%Y-%m-%dT%H:%M:%S"),
+                            "%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -585,7 +585,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-03-10T10:00:00",
+                        registration_event_datetime="2023-03-10T10:00:00+0000",
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -600,7 +600,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -613,7 +613,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-03-10T09:30:00",
+                        registration_event_datetime="2023-03-10T09:30:00+0000",
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -624,7 +624,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-03-10T10:00:00",
+                        registration_event_datetime="2023-03-10T10:00:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -643,7 +643,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -657,7 +657,7 @@ class TestSlaStatus(TestBase):
                     create_sample_event(
                         conversation_id=conversation_id,
                         registration_event_datetime=now_minus_20_mins.strftime(
-                            "%Y-%m-%dT%H:%M:%S"),
+                            "%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -668,7 +668,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-03-10T10:00:00",
+                        registration_event_datetime="2023-03-10T10:00:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -683,7 +683,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -696,7 +696,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-03-10T09:30:00",
+                        registration_event_datetime="2023-03-10T09:30:00+0000",
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -707,7 +707,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-03-10T10:00:00",
+                        registration_event_datetime="2023-03-10T10:00:00+0000",
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -726,7 +726,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -740,7 +740,7 @@ class TestSlaStatus(TestBase):
                     create_sample_event(
                         conversation_id=conversation_id,
                         registration_event_datetime=now_minus_20_mins.strftime(
-                            "%Y-%m-%dT%H:%M:%S"),
+                            "%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -751,7 +751,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-03-10T10:00:00",
+                        registration_event_datetime="2023-03-10T10:00:00+0000",
                         event_type=EventType.EHR_RESPONSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -766,7 +766,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -779,7 +779,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime="2023-03-10T09:30:00",
+                        registration_event_datetime="2023-03-10T09:30:00+0000",
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"
@@ -798,7 +798,7 @@ class TestSlaStatus(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversation_id,
-                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         payload=create_transfer_compatibility_payload(
                             internalTransfer=False,
@@ -812,7 +812,7 @@ class TestSlaStatus(TestBase):
                     create_sample_event(
                         conversation_id=conversation_id,
                         registration_event_datetime=now_minus_20_mins.strftime(
-                            "%Y-%m-%dT%H:%M:%S"),
+                            "%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_REQUESTS.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP"

--- a/tests/test_transfer_status_report/test_transfer_status_report_base.py
+++ b/tests/test_transfer_status_report/test_transfer_status_report_base.py
@@ -8,7 +8,8 @@ from helpers.splunk \
     import get_telemetry_from_splunk,  create_sample_event, set_variables_on_query, \
     create_integration_payload, create_transfer_compatibility_payload
 from tests.test_base import TestBase, EventType
-from datetime import datetime, timedelta
+from datetime import timedelta
+from helpers.datetime_helper import datetime_utc_now
 
 
 class TestTransferStatusReportBase(TestBase):
@@ -583,7 +584,7 @@ class TestTransferStatusReportBase(TestBase):
 
         try:
             # test requires a datetime less than 20mins
-            now_minus_18_mins = datetime.today() - timedelta(hours=0, minutes=18)
+            now_minus_18_mins = datetime_utc_now() - timedelta(hours=0, minutes=18)
             self.LOG.info(f"now_minus_18_mins: {now_minus_18_mins}")
 
             # test_#1 - compatible and within SLA
@@ -743,7 +744,7 @@ class TestTransferStatusReportBase(TestBase):
             # test_#2 - compatible and TOTAL TRANSFER TIME OUTSIDE SLA 24 HOURS = true
 
             # test requires a datetime greater than 24 hours
-            now_minus_25_hours = datetime.today() - timedelta(hours=25, minutes=0)
+            now_minus_25_hours = datetime_utc_now() - timedelta(hours=25, minutes=0)
             self.LOG.info(f"now_minus_25_mins: {now_minus_25_hours}")
 
             conversationId = 'test_technical_failure_TOTAL_TRANSFER_TIME_OUTSIDE_SLA_24_HOURS'
@@ -752,7 +753,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversationId,
-                        registration_event_datetime=datetime.today().strftime("%Y-%m-%dT%H:%M:%S%z"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -778,7 +779,7 @@ class TestTransferStatusReportBase(TestBase):
             conversationId = 'test_technical_failure_EHR_SENDING_OUTSIDE_SLA'
 
              # test requires a datetime less than 20mins
-            now_over_20_mins = datetime.today() - timedelta(hours=0, minutes=21)
+            now_over_20_mins = datetime_utc_now() - timedelta(hours=0, minutes=21)
             self.LOG.info(f"now_minus_18_mins: {now_over_20_mins}")
 
             index.submit(
@@ -811,7 +812,7 @@ class TestTransferStatusReportBase(TestBase):
             conversationId = 'test_technical_failure_EHR_REQUESTING_OUTSIDE_SLA'
 
              # test requires a datetime less than 20mins
-            now_over_20_mins = datetime.today() - timedelta(hours=0, minutes=21)
+            now_over_20_mins = datetime_utc_now() - timedelta(hours=0, minutes=21)
             self.LOG.info(f"now_minus_18_mins: {now_over_20_mins}")
 
             index.submit(
@@ -833,7 +834,7 @@ class TestTransferStatusReportBase(TestBase):
             # test_#5 - in-progress test to check technical failure count working correctly.
 
              # test requires a datetime greater than 24 hours
-            now_minus_23_hours = datetime.today() - timedelta(hours=23, minutes=0)
+            now_minus_23_hours = datetime_utc_now() - timedelta(hours=23, minutes=0)
             self.LOG.info(f"now_minus_23_hours: {now_minus_23_hours}")
 
             conversationId = 'test_technical_failure_status_IN_PROGRESS'
@@ -842,7 +843,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversationId,
-                        registration_event_datetime=datetime.today().strftime("%Y-%m-%dT%H:%M:%S%z"),
+                        registration_event_datetime=datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",

--- a/tests/test_transfer_status_report/test_transfer_status_report_base.py
+++ b/tests/test_transfer_status_report/test_transfer_status_report_base.py
@@ -24,7 +24,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_total_eligible_for_electronic_transfer_1',
-                        registration_event_datetime="2023-03-10T08:00:00",
+                        registration_event_datetime="2023-03-10T08:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -41,7 +41,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_total_eligible_for_electronic_transfer_2',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -58,7 +58,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_total_eligible_for_electronic_transfer_3',
-                        registration_event_datetime="2023-03-10T10:00:00",
+                        registration_event_datetime="2023-03-10T10:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -107,7 +107,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_successfully_integrated_1',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -124,7 +124,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_successfully_integrated_1',
-                        registration_event_datetime="2023-03-10T08:00:00",
+                        registration_event_datetime="2023-03-10T08:00:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(outcome="INTEGRATED")
                     )),
@@ -136,7 +136,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_successfully_integrated_2',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -153,7 +153,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_successfully_integrated_2',
-                        registration_event_datetime="2023-03-10T08:10:00",
+                        registration_event_datetime="2023-03-10T08:10:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(
                             outcome="INTEGRATED_AND_SUPPRESSED")
@@ -166,7 +166,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_successfully_integrated_3',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -183,7 +183,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_successfully_integrated_3',
-                        registration_event_datetime="2023-03-10T08:20:00",
+                        registration_event_datetime="2023-03-10T08:20:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(
                             outcome="SUPPRESSED_AND_REACTIVATED")
@@ -196,7 +196,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_successfully_integrated_rejected',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -213,7 +213,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_successfully_integrated_rejected',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(outcome="REJECTED")
                     )),
@@ -225,7 +225,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_successfully_integrated_failed_to_integrate_#1',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -242,7 +242,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_successfully_integrated_failed_to_integrate_#1',
-                        registration_event_datetime="2023-03-10T09:10:00",
+                        registration_event_datetime="2023-03-10T09:10:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(
                             outcome="FAILED_TO_INTEGRATE")
@@ -255,7 +255,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_successfully_integrated_failed_to_integrate_#2',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -272,7 +272,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_successfully_integrated_failed_to_integrate_#2',
-                        registration_event_datetime="2023-03-10T09:10:00",
+                        registration_event_datetime="2023-03-10T09:10:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(
                             outcome="FAILED_TO_INTEGRATE")
@@ -318,7 +318,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_rejected_1',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -335,7 +335,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_rejected_1',
-                        registration_event_datetime="2023-03-10T08:00:00",
+                        registration_event_datetime="2023-03-10T08:00:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(outcome="INTEGRATED")
                     )),
@@ -347,7 +347,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_rejected_2',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -364,7 +364,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_rejected_2',
-                        registration_event_datetime="2023-03-10T08:10:00",
+                        registration_event_datetime="2023-03-10T08:10:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(
                             outcome="INTEGRATED_AND_SUPPRESSED")
@@ -377,7 +377,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_rejected_3',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -394,7 +394,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_rejected_3',
-                        registration_event_datetime="2023-03-10T08:20:00",
+                        registration_event_datetime="2023-03-10T08:20:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(
                             outcome="SUPPRESSED_AND_REACTIVATED")
@@ -407,7 +407,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_rejected_4',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -424,7 +424,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_rejected_4',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(outcome="REJECTED")
                     )),
@@ -469,7 +469,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'awaiting_integration_1',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -486,7 +486,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'awaiting_integration_1',
-                        registration_event_datetime="2023-03-10T09:10:00",
+                        registration_event_datetime="2023-03-10T09:10:00+0000",
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value
                     )),
                 sourcetype="myevent")
@@ -497,7 +497,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'awaiting_integration_2',
-                        registration_event_datetime="2023-03-10T09:20:00",
+                        registration_event_datetime="2023-03-10T09:20:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -514,7 +514,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'awaiting_integration_2',
-                        registration_event_datetime="2023-03-10T09:30:00",
+                        registration_event_datetime="2023-03-10T09:30:00+0000",
                         event_type=EventType.READY_TO_INTEGRATE_STATUSES.value
                     )),
                 sourcetype="myevent")
@@ -525,7 +525,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'awaiting_integration_3',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -542,7 +542,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         'awaiting_integration_3',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(outcome="REJECTED")
                     )),
@@ -593,7 +593,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversationId,
-                        registration_event_datetime="2023-03-10T08:00:00",
+                        registration_event_datetime="2023-03-10T08:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -611,7 +611,7 @@ class TestTransferStatusReportBase(TestBase):
                     create_sample_event(
                         conversation_id=conversationId,
                         registration_event_datetime=now_minus_18_mins.strftime(
-                            "%Y-%m-%dT%H:%M:%S"),
+                            "%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_REQUESTS.value
                     )),
                 sourcetype="myevent")
@@ -624,7 +624,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversationId,
-                        registration_event_datetime="2023-03-10T08:00:00",
+                        registration_event_datetime="2023-03-10T08:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -641,7 +641,7 @@ class TestTransferStatusReportBase(TestBase):
                     create_sample_event(
                         conversation_id=conversationId,
                         registration_event_datetime=now_minus_18_mins.strftime(
-                            "%Y-%m-%dT%H:%M:%S"),
+                            "%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_REQUESTS.value
                     )),
                 sourcetype="myevent")
@@ -655,7 +655,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversationId,
-                        registration_event_datetime="2023-03-10T08:00:00",
+                        registration_event_datetime="2023-03-10T08:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -671,7 +671,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversationId,
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.EHR_REQUESTS.value
                     )),
                 sourcetype="myevent")
@@ -718,7 +718,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversationId,
-                        registration_event_datetime="2023-03-10T08:00:00",
+                        registration_event_datetime="2023-03-10T08:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -734,7 +734,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversationId,
-                        registration_event_datetime="2023-03-10T08:10:00",
+                        registration_event_datetime="2023-03-10T08:10:00+0000",
                         event_type=EventType.EHR_INTEGRATIONS.value,
                         payload=create_integration_payload(outcome="FAILED_TO_INTEGRATE")
                     )),
@@ -752,7 +752,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversationId,
-                        registration_event_datetime=datetime.today().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime.today().strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -768,7 +768,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversationId,
-                        registration_event_datetime=now_minus_25_hours.strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=now_minus_25_hours.strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_RESPONSES.value
                     )),
                 sourcetype="myevent")
@@ -785,7 +785,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversationId,
-                        registration_event_datetime="2023-03-10T08:00:00",
+                        registration_event_datetime="2023-03-10T08:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -801,7 +801,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversationId,
-                        registration_event_datetime=now_over_20_mins.strftime("%Y-%m-%dT%H:%M:%S"),                        
+                        registration_event_datetime=now_over_20_mins.strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_REQUESTS.value
                     )),
                 sourcetype="myevent")
@@ -818,7 +818,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversationId,
-                        registration_event_datetime=now_over_20_mins.strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=now_over_20_mins.strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -842,7 +842,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversationId,
-                        registration_event_datetime=datetime.today().strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=datetime.today().strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -858,7 +858,7 @@ class TestTransferStatusReportBase(TestBase):
                 json.dumps(
                     create_sample_event(
                         conversation_id=conversationId,
-                        registration_event_datetime=now_minus_23_hours.strftime("%Y-%m-%dT%H:%M:%S"),
+                        registration_event_datetime=now_minus_23_hours.strftime("%Y-%m-%dT%H:%M:%S%z"),
                         event_type=EventType.EHR_RESPONSES.value
                     )),
                 sourcetype="myevent")            

--- a/tests/test_transfer_status_report/test_transfer_status_report_snapshot_outputs.py
+++ b/tests/test_transfer_status_report/test_transfer_status_report_snapshot_outputs.py
@@ -25,7 +25,7 @@ class TestTransferStatusReportSnapshotOutputs(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_total_eligible_for_electronic_transfer_1',
-                        registration_event_datetime="2023-03-10T08:00:00",
+                        registration_event_datetime="2023-03-10T08:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -42,7 +42,7 @@ class TestTransferStatusReportSnapshotOutputs(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_total_eligible_for_electronic_transfer_2',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -59,7 +59,7 @@ class TestTransferStatusReportSnapshotOutputs(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_total_eligible_for_electronic_transfer_3',
-                        registration_event_datetime="2023-03-10T10:00:00",
+                        registration_event_datetime="2023-03-10T10:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -114,7 +114,7 @@ class TestTransferStatusReportSnapshotOutputs(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_total_eligible_for_electronic_transfer_1',
-                        registration_event_datetime="2023-03-10T08:00:00",
+                        registration_event_datetime="2023-03-10T08:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -131,7 +131,7 @@ class TestTransferStatusReportSnapshotOutputs(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_total_eligible_for_electronic_transfer_2',
-                        registration_event_datetime="2023-03-10T09:00:00",
+                        registration_event_datetime="2023-03-10T09:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -148,7 +148,7 @@ class TestTransferStatusReportSnapshotOutputs(TestBase):
                 json.dumps(
                     create_sample_event(
                         'test_total_eligible_for_electronic_transfer_3',
-                        registration_event_datetime="2023-03-10T10:00:00",
+                        registration_event_datetime="2023-03-10T10:00:00+0000",
                         event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                         sendingPracticeSupplierName="EMIS",
                         requestingPracticeSupplierName="TPP",
@@ -202,7 +202,7 @@ class TestTransferStatusReportSnapshotOutputs(TestBase):
                     json.dumps(
                         create_sample_event(
                             'test_total_eligible_for_electronic_transfer_1',
-                            registration_event_datetime="2023-03-10T08:00:00",
+                            registration_event_datetime="2023-03-10T08:00:00+0000",
                             event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                             sendingPracticeSupplierName="EMIS",
                             requestingPracticeSupplierName="TPP",
@@ -219,7 +219,7 @@ class TestTransferStatusReportSnapshotOutputs(TestBase):
                     json.dumps(
                         create_sample_event(
                             'test_total_eligible_for_electronic_transfer_2',
-                            registration_event_datetime="2023-03-10T09:00:00",
+                            registration_event_datetime="2023-03-10T09:00:00+0000",
                             event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                             sendingPracticeSupplierName="EMIS",
                             requestingPracticeSupplierName="TPP",
@@ -236,7 +236,7 @@ class TestTransferStatusReportSnapshotOutputs(TestBase):
                     json.dumps(
                         create_sample_event(
                             'test_total_eligible_for_electronic_transfer_3',
-                            registration_event_datetime="2023-03-10T10:00:00",
+                            registration_event_datetime="2023-03-10T10:00:00+0000",
                             event_type=EventType.TRANSFER_COMPATIBILITY_STATUSES.value,
                             sendingPracticeSupplierName="EMIS",
                             requestingPracticeSupplierName="TPP",


### PR DESCRIPTION
Refactor all test code to use a UTC datetime. When datetimes are converted from strings the tzinfo has to be included and set to "+0000".